### PR TITLE
Community 화면 구현 중 1차 PR

### DIFF
--- a/App.js
+++ b/App.js
@@ -4,24 +4,26 @@ import { createStackNavigator } from '@react-navigation/stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 
-import LoginScreen      from './screens/LoginScreen';
-import HomeScreen       from './screens/HomeScreen';
+import LoginScreen      from './screens/LoginScreen';     // Login
 import UserTypeScreen   from './screens/UserTypeScreen';
 import UserInfoScreen   from './screens/UserInfoScreen';
-import CalendarScreen   from "./screens/CalendarScreen";
-import MessageScreen    from "./screens/MessageScreen";
-import CommunityScreen  from "./screens/CommunityScreen";
+import HomeScreen       from './screens/HomeScreen';      // Home
+import CalendarScreen   from "./screens/CalendarScreen";  // Calendar
 import MonthlyScreen    from './screens/MonthlyScreen';
-import ScheduleInput    from './screens/ScheduleInput'; // 상대 경로 수정
+import ScheduleInput    from './screens/ScheduleInput';
+import MessageScreen    from "./screens/MessageScreen";   // Message
+import CommunityScreen  from "./screens/CommunityScreen"; // Community
+import NewPost          from "./screens/NewPostScreen";
 
 const Stack = createStackNavigator();
 const Tab = createBottomTabNavigator();
+
 
 const TabNavigator = () => {
   return (
     <Tab.Navigator
       
-      initialRouteName="Home"
+      initialRouteName="Back"
 
       screenOptions={({ route }) => ({
         tabBarIcon: ({ focused, color, size }) => {
@@ -77,9 +79,13 @@ const App = () => {
         <Stack.Screen name="UserType" component={UserTypeScreen}  options={tabScreenOptions} />
         <Stack.Screen name="UserInfo" component={UserInfoScreen}  options={tabScreenOptions} />
         <Stack.Screen name="Home"     component={TabNavigator}    options={{ headerShown: false }} />
+
         <Stack.Screen name="CalendarScreen" component={CalendarScreen}  options={{ title: '캘린더' }} />
         <Stack.Screen name="MonthlyScreen"  component={MonthlyScreen}   options={{ title: '일정 관리' }} />
         <Stack.Screen name="ScheduleInput"  component={ScheduleInput}   options={{ title: '일정 추가' }} />
+        
+        <Stack.Screen name="CommunityScreen" component={CommunityScreen}/>
+        <Stack.Screen name="NewPost"         component={NewPost} options={tabScreenOptions} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/screens/CommunityScreen.js
+++ b/screens/CommunityScreen.js
@@ -1,33 +1,121 @@
-import React from 'react';
+import React, {useState} from 'react';
 import { 
-  SafeAreaView,
-  VirtualizedList,
+  SafeAreaView, 
   StyleSheet, 
   View, 
-  Text, 
-  Button 
+  FlatList,
+  TouchableOpacity,
+  Text,
 } from 'react-native';
 
-const Item = ({title}) => (
-  <View style={styles.item}>
-    <Text style={styles.title}>{title}</Text>
-  </View>
-);
+export default CommunityScreen = ({ navigation }) => {
+  const [posts, setPosts] = useState([
+    { id: '1', 
+      title: 'Test Post', 
+      content: 'This is first Post.', 
+      createdAt: '2024-10-08',        // 날짜&시간 API로? 불러와야 함
+      author: 'TestUser',             // 사용자 id 불러와야함
+      likes: 5, 
+      comments: 2, 
+      isAnonymous: false 
+    },
+  ]);
 
-export default function CommunityScreen({ navigation }) {
-    return (
-      <View style={styles.screen}>
+  const getFirstLine = (text, maxLength = 20) => {
+    const firstLine = text.split('\n')[0];
+    if (firstLine.length <= maxLength) {
+      return firstLine;
+    }
+    return firstLine.split('').slice(0, maxLength).join('') + '...';
+  };
+
+  const renderItem = ({ item }) => (
+    <View style={styles.postContainer}>
+      <View style={styles.postItem}>
+        <View style={styles.postContent}>
+          <Text style={styles.postTitle}>{item.title}</Text>
+          <Text style={styles.postPreview}>{getFirstLine(item.content)}</Text>
+          <Text style={styles.postInfo}>{item.createdAt} • {item.isAnonymous ? '익명' : item.author}</Text>
+          <Text style={styles.postStats}>Likes {item.likes} • Comments {item.comments}</Text>
+        </View>
       </View>
-    )
-}
+    </View>
+  );
+
+  return (
+    <View style={styles.screenContainer}>
+      <FlatList
+        data={posts}
+        renderItem={renderItem}
+        keyExtractor={item => item.id}
+      />
+      <View style={styles.buttonContainer}>
+        <TouchableOpacity
+          style={styles.button}
+          onPress={() => navigation.navigate('NewPost', { onPostCreated: (newPost) => {
+            setPosts(currentPosts => [newPost, ...currentPosts]);
+          }})}
+        >
+          <Text style={styles.buttonText}>글 작성하기</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+};
 const styles = StyleSheet.create({
-  screen: {
+  // screen style
+  screenContainer: {
     flex: 1,
     backgroundColor: '#E5D0FD',
-    alignItems: 'left',
+  },
+  // Post container style
+  postContainer: {
+    alignSelf: 'center',
+    width: '92%',
+    backgroundColor: '#fff',
+    borderRadius: 10,
+    marginTop: 18,
+    padding: 20,
+  },
+  // post items style
+  postItem: {
+  },
+  postContent: {
+  },
+  postTitle: {
+    paddingBottom: 5,
+    margin: 0,
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  postPreview: {
+    paddingBottom: 5,
+  },
+  postInfo: {
+    marginTop: 5,
+    fontSize: 14,
+    color: '#6b7280',
+},
+  postStats: {
+    fontSize: 14,
+    color: '#6b7280',
+},
+  // button style
+  buttonContainer: {
+    flexDirection: 'column',
+    justifyContent: 'flex-end',
+    alignItems: 'flex-end',
+    position: 'absolute',
+    bottom: 20,
+    right: 20,
   },
   button: {
     backgroundColor: '#7030B8',
-    fontSize: 600,
+    borderRadius: 10,
+    padding: 10,
+  },
+  buttonText: {
+    color: '#E6E6FA',
+    fontWeight: '700',
   },
 });

--- a/screens/MessageScreen.js
+++ b/screens/MessageScreen.js
@@ -71,6 +71,7 @@ const styles = StyleSheet.create({
     messageContainer: {
         alighSelf: 'flex-end',
         marginVertical: '1%',
+        borderRadius: Platform.OS === 'ios' ? '5%' : 5,
     },
     message: {
         backgroundColor: '#fff',
@@ -89,6 +90,7 @@ const styles = StyleSheet.create({
         borderColor: '#7030B8',
         borderWidth: 1,
         borderRadius: 5,
+        borderRadius: Platform.OS === 'ios' ? '2.5%' : 5,
         padding: '3%',
         marginRight: '5%',
         marginBottom: '3%',
@@ -96,7 +98,7 @@ const styles = StyleSheet.create({
     sendButton: {
         backgroundColor: '#7030B8',
         padding: '3%',
-        borderRadius: '3%',
+        borderRadius: Platform.OS === 'ios' ? '2.5%' : 3,
         marginBottom: '3%',
     },
     sendButtonText: {

--- a/screens/NewPostScreen.js
+++ b/screens/NewPostScreen.js
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import { 
+  StyleSheet, 
+  View, 
+  TextInput, 
+  Text, 
+  SafeAreaView,
+  Switch,
+  TouchableOpacity,
+  ScrollView,
+  Platform,
+  Keyboard
+} from 'react-native';
+
+export default NewPost = ({ route, navigation }) => {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [isAnonymous, setIsAnonymous] = useState(false);
+
+  const handleSubmit = () => {
+    const newPost = {
+      id: Date.now().toString(),
+      title,
+      content,
+      author: isAnonymous ? '익명' : '사용자',
+      createdAt: new Date().toISOString().split('T')[0],
+      likes: 0,     // 좋아요 기능 추후 추가
+      comments: 0,  // 댓글 기능 추후 추가
+      isAnonymous,
+    };
+    route.params.onPostCreated(newPost);
+    navigation.goBack();
+  };
+
+  return (
+    <View style={styles.screenContainer}>
+      <View style={styles.container}>
+        <ScrollView keyboardDismissMode="on-drag">
+          <TextInput
+            style={styles.inputTitle}
+            placeholder="Title"
+            value={title}
+            onChangeText={setTitle}
+          />
+          <View style={styles.anonymousToggle}>
+            <Text>Anonymous</Text>
+            <Switch style={styles.switch} value={isAnonymous} onValueChange={setIsAnonymous} />
+          </View>
+          <TextInput
+            style={styles.inputContent}
+            placeholder="내용을 입력하세요"
+            multiline
+            value={content}
+            onChangeText={setContent}
+            onBlur={() => Keyboard.dismiss()}
+          />
+        </ScrollView>
+        <View style={styles.buttonContainer}>
+            <TouchableOpacity style={styles.button} onPress={handleSubmit}>
+              <Text style={styles.buttonText}>작성 완료</Text>
+            </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  // screen style
+  screenContainer: {
+    flex: 1,
+    backgroundColor: '#E5D0FD',
+  },
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: '#E5D0FD',
+  },
+  label: {
+    marginBottom: 5,
+    fontSize: 16,
+  },
+  inputTitle: {
+    flex: 0.04,
+    backgroundColor: '#fff',
+    borderRadius: Platform.OS === 'ios' ? '5%' : 10,
+    marginVertical: '2%',
+    padding: 10,
+  },
+  switch: {
+  },
+  inputContent: {
+    minHeight: '100%',
+    maxHeight: '150%',
+    backgroundColor: '#fff',
+    borderRadius: Platform.OS === 'ios' ? '5%' : 10,
+    marginTop: 20,
+    padding: 10,
+  },
+  anonymousToggle: {},
+  contentInput: {},
+  // button style
+  buttonContainer: {
+    flexDirection: 'column',
+    justifyContent: 'flex-end',
+    alignItems: 'flex-end',
+    position: 'absolute',
+    bottom: 20,
+    right: 20,
+  },
+  button: {
+    backgroundColor: '#7030B8',
+    borderRadius: 10,
+    padding: 10,
+  },
+  buttonText: {
+    color: '#E6E6FA',
+    fontWeight: '700',
+  },
+});

--- a/screens/NewPostScreen.js
+++ b/screens/NewPostScreen.js
@@ -87,18 +87,18 @@ const styles = StyleSheet.create({
     marginVertical: '2%',
     padding: 10,
   },
-  switch: {
-  },
+  // switch: {},
   inputContent: {
-    minHeight: '100%',
-    maxHeight: '150%',
+    minHeight: Platform.OS === 'ios' ? '100%' : 150,
+    maxHeight: Platform.OS === 'ios' ? '150%' : 150,
     backgroundColor: '#fff',
     borderRadius: Platform.OS === 'ios' ? '5%' : 10,
     marginTop: 20,
     padding: 10,
   },
-  anonymousToggle: {},
-  contentInput: {},
+  // anonymousToggle: {},
+  // contentInput: {},
+  
   // button style
   buttonContainer: {
     flexDirection: 'column',

--- a/screens/UserInfoScreen.js
+++ b/screens/UserInfoScreen.js
@@ -6,7 +6,8 @@ import {
   Button, 
   Alert, 
   TouchableOpacity, 
-  StyleSheet 
+  StyleSheet,
+  Platform
 } from 'react-native';
 
 const UserInfoScreen = ({ navigation }) => {
@@ -110,14 +111,14 @@ const styles = StyleSheet.create({
   input: {
     flex: 1,
     backgroundColor: '#fff',
-    borderRadius: '5%',
+    borderRadius: Platform.OS === 'ios' ? '5%' : 10,
     paddingHorizontal: 10,
     padding: '1%',
   },
   duplicateButton: {
     backgroundColor: '#ccc',
     padding: 10,
-    borderRadius: '5%',
+    borderRadius: Platform.OS === 'ios' ? '5%' : 10,
     marginLeft: 10,
   },
   duplicateButtonText: {
@@ -131,7 +132,7 @@ const styles = StyleSheet.create({
   signUpButton: {
     backgroundColor: '#6A5ACD',
     padding: '3.5%',
-    borderRadius: '5%',
+    borderRadius: Platform.OS === 'ios' ? '5%' : 10,
     alignItems: 'center',
   },
   signUpButtonText: {
@@ -143,7 +144,7 @@ const styles = StyleSheet.create({
     top: '40%',
     backgroundColor: '#fff',
     padding: 20,
-    borderRadius: 10,
+    borderRadius: Platform.OS === 'ios' ? '5%' : 10,
     width: '80%',
     alignItems: 'center',
     borderWidth: 1,


### PR DESCRIPTION
### CommunityScreen.js
- 게시글 목록 구현
  - 제목
  - 내용 (첫 줄의 20자까지 표시. 나머지는 '...'으로 줄임 표시)
  - 날짜
    - 이 부분은 아직 API로 현재 날짜를 불러오게 구현하지 않아서, 임시로 2024-10-08 날짜를 넣어뒀습니다
  - user 이름 (사용자가 글 작성시 익명을 선택하면 익명으로 표시)
  - 좋아요, 댓글 개수 (이 부분도 임의로 숫자 부여해뒀습니당)

[글 작성하기 버튼] -> NewPostScreen.js로 이동

 ### NewPostScreen.js
- 글 제목 입력칸
  - 그냥 제목~~
- 익명 여부 선택 스위치
  - 스위치를 끄면 작성자가 사용자 닉네임으로, 켜면 익명으로 표시됩니다.
  - 현재는 회원가입시 이름을 따로 받고있지는 않아서, 임시로 사용자/익명 으로 구분해뒀습니다.
- 글 내용 입력칸
  - 내용 입력 칸의 최소, 최대 높이를 설정해뒀습니다.
  - iOS 기준, 입력창을 클릭하면 키보드가 올라오고, 화면을 스크롤(아래로 스와이프)하면 키보드가 내려가도록 구현해뒀습니다.
  - 게시글 목록에서는, 해당 내용의 첫 문장 (줄바꿈 문자 기준)의 20자까지만 확인 가능합니다. 
- 작성 완료 버튼
  - 버튼 클릭시 게시글 목록 화면으로 돌아가게 되고, 목록에서 방금 작성한 글을 확인해 볼 수 있습니다.